### PR TITLE
Migrating from master/slave lingo

### DIFF
--- a/yoctolib/yocto_serialport.py
+++ b/yoctolib/yocto_serialport.py
@@ -1120,7 +1120,7 @@ class YSerialPort(YFunction):
     def writeMODBUS(self, hexString):
         """
         Sends a MODBUS message (provided as a hexadecimal string) to the serial port.
-        The message must start with the slave address. The MODBUS CRC/LRC is
+        The message must start with the subordinate address. The MODBUS CRC/LRC is
         automatically added by the function. This function does not wait for a reply.
 
         @param hexString : a hexadecimal message string, including device address but no CRC/LRC
@@ -1131,12 +1131,12 @@ class YSerialPort(YFunction):
         """
         return self.sendCommand(":" + hexString)
 
-    def queryMODBUS(self, slaveNo, pduBytes):
+    def queryMODBUS(self, subordinateNo, pduBytes):
         """
-        Sends a message to a specified MODBUS slave connected to the serial port, and reads the
+        Sends a message to a specified MODBUS subordinate connected to the serial port, and reads the
         reply, if any. The message is the PDU, provided as a vector of bytes.
 
-        @param slaveNo : the address of the slave MODBUS device to query
+        @param subordinateNo : the address of the subordinate MODBUS device to query
         @param pduBytes : the message to send (PDU), as a vector of bytes. The first byte of the
                 PDU is the MODBUS function code.
 
@@ -1158,8 +1158,8 @@ class YSerialPort(YFunction):
         # hexb
         funCode = pduBytes[0]
         nib = ((funCode) >> (4))
-        pat = "" + ("%02X" % slaveNo) + "[" + ("%X" % nib) + "" + ("%X" % (nib+8)) + "]" + ("%X" % ((funCode) & (15))) + ".*"
-        cmd = "" + ("%02X" % slaveNo) + "" + ("%02X" % funCode)
+        pat = "" + ("%02X" % subordinateNo) + "[" + ("%X" % nib) + "" + ("%X" % (nib+8)) + "]" + ("%X" % ((funCode) & (15))) + ".*"
+        cmd = "" + ("%02X" % subordinateNo) + "" + ("%02X" % funCode)
         i = 1
         while i < len(pduBytes):
             cmd = "" + cmd + "" + ("%02X" % ((pduBytes[i]) & (0xff)))
@@ -1169,7 +1169,7 @@ class YSerialPort(YFunction):
         msgs = self._download(url)
         reps = self._json_get_array(msgs)
         if not (len(reps) > 1):
-            self._throw(YAPI.IO_ERROR, "no reply from slave")
+            self._throw(YAPI.IO_ERROR, "no reply from subordinate")
             return res
         if len(reps) > 1:
             rep = self._json_get_string(YString2Byte(reps[0]))
@@ -1195,12 +1195,12 @@ class YSerialPort(YFunction):
                     return res
         return res
 
-    def modbusReadBits(self, slaveNo, pduAddr, nBits):
+    def modbusReadBits(self, subordinateNo, pduAddr, nBits):
         """
         Reads one or more contiguous internal bits (or coil status) from a MODBUS serial device.
         This method uses the MODBUS function code 0x01 (Read Coils).
 
-        @param slaveNo : the address of the slave MODBUS device to query
+        @param subordinateNo : the address of the subordinate MODBUS device to query
         @param pduAddr : the relative address of the first bit/coil to read (zero-based)
         @param nBits : the number of bits/coils to read
 
@@ -1223,7 +1223,7 @@ class YSerialPort(YFunction):
         pdu.append(((nBits) & (0xff)))
 
 
-        reply = self.queryMODBUS(slaveNo, pdu)
+        reply = self.queryMODBUS(subordinateNo, pdu)
         if len(reply) == 0:
             return res
         if reply[0] != pdu[0]:
@@ -1248,12 +1248,12 @@ class YSerialPort(YFunction):
 
         return res
 
-    def modbusReadInputBits(self, slaveNo, pduAddr, nBits):
+    def modbusReadInputBits(self, subordinateNo, pduAddr, nBits):
         """
         Reads one or more contiguous input bits (or discrete inputs) from a MODBUS serial device.
         This method uses the MODBUS function code 0x02 (Read Discrete Inputs).
 
-        @param slaveNo : the address of the slave MODBUS device to query
+        @param subordinateNo : the address of the subordinate MODBUS device to query
         @param pduAddr : the relative address of the first bit/input to read (zero-based)
         @param nBits : the number of bits/inputs to read
 
@@ -1276,7 +1276,7 @@ class YSerialPort(YFunction):
         pdu.append(((nBits) & (0xff)))
 
 
-        reply = self.queryMODBUS(slaveNo, pdu)
+        reply = self.queryMODBUS(subordinateNo, pdu)
         if len(reply) == 0:
             return res
         if reply[0] != pdu[0]:
@@ -1301,12 +1301,12 @@ class YSerialPort(YFunction):
 
         return res
 
-    def modbusReadRegisters(self, slaveNo, pduAddr, nWords):
+    def modbusReadRegisters(self, subordinateNo, pduAddr, nWords):
         """
         Reads one or more contiguous internal registers (holding registers) from a MODBUS serial device.
         This method uses the MODBUS function code 0x03 (Read Holding Registers).
 
-        @param slaveNo : the address of the slave MODBUS device to query
+        @param subordinateNo : the address of the subordinate MODBUS device to query
         @param pduAddr : the relative address of the first holding register to read (zero-based)
         @param nWords : the number of holding registers to read
 
@@ -1328,7 +1328,7 @@ class YSerialPort(YFunction):
         pdu.append(((nWords) & (0xff)))
 
 
-        reply = self.queryMODBUS(slaveNo, pdu)
+        reply = self.queryMODBUS(subordinateNo, pdu)
         if len(reply) == 0:
             return res
         if reply[0] != pdu[0]:
@@ -1346,12 +1346,12 @@ class YSerialPort(YFunction):
 
         return res
 
-    def modbusReadInputRegisters(self, slaveNo, pduAddr, nWords):
+    def modbusReadInputRegisters(self, subordinateNo, pduAddr, nWords):
         """
         Reads one or more contiguous input registers (read-only registers) from a MODBUS serial device.
         This method uses the MODBUS function code 0x04 (Read Input Registers).
 
-        @param slaveNo : the address of the slave MODBUS device to query
+        @param subordinateNo : the address of the subordinate MODBUS device to query
         @param pduAddr : the relative address of the first input register to read (zero-based)
         @param nWords : the number of input registers to read
 
@@ -1373,7 +1373,7 @@ class YSerialPort(YFunction):
         pdu.append(((nWords) & (0xff)))
 
 
-        reply = self.queryMODBUS(slaveNo, pdu)
+        reply = self.queryMODBUS(subordinateNo, pdu)
         if len(reply) == 0:
             return res
         if reply[0] != pdu[0]:
@@ -1391,12 +1391,12 @@ class YSerialPort(YFunction):
 
         return res
 
-    def modbusWriteBit(self, slaveNo, pduAddr, value):
+    def modbusWriteBit(self, subordinateNo, pduAddr, value):
         """
         Sets a single internal bit (or coil) on a MODBUS serial device.
         This method uses the MODBUS function code 0x05 (Write Single Coil).
 
-        @param slaveNo : the address of the slave MODBUS device to drive
+        @param subordinateNo : the address of the subordinate MODBUS device to drive
         @param pduAddr : the relative address of the bit/coil to set (zero-based)
         @param value : the value to set (0 for OFF state, non-zero for ON state)
 
@@ -1418,7 +1418,7 @@ class YSerialPort(YFunction):
         pdu.append(0x00)
 
 
-        reply = self.queryMODBUS(slaveNo, pdu)
+        reply = self.queryMODBUS(subordinateNo, pdu)
         if len(reply) == 0:
             return res
         if reply[0] != pdu[0]:
@@ -1426,12 +1426,12 @@ class YSerialPort(YFunction):
         res = 1
         return res
 
-    def modbusWriteBits(self, slaveNo, pduAddr, bits):
+    def modbusWriteBits(self, subordinateNo, pduAddr, bits):
         """
         Sets several contiguous internal bits (or coils) on a MODBUS serial device.
         This method uses the MODBUS function code 0x0f (Write Multiple Coils).
 
-        @param slaveNo : the address of the slave MODBUS device to drive
+        @param subordinateNo : the address of the subordinate MODBUS device to drive
         @param pduAddr : the relative address of the first bit/coil to set (zero-based)
         @param bits : the vector of bits to be set (one integer per bit)
 
@@ -1474,7 +1474,7 @@ class YSerialPort(YFunction):
             pdu.append(val)
 
 
-        reply = self.queryMODBUS(slaveNo, pdu)
+        reply = self.queryMODBUS(subordinateNo, pdu)
         if len(reply) == 0:
             return res
         if reply[0] != pdu[0]:
@@ -1483,12 +1483,12 @@ class YSerialPort(YFunction):
         res = res + reply[4]
         return res
 
-    def modbusWriteRegister(self, slaveNo, pduAddr, value):
+    def modbusWriteRegister(self, subordinateNo, pduAddr, value):
         """
         Sets a single internal register (or holding register) on a MODBUS serial device.
         This method uses the MODBUS function code 0x06 (Write Single Register).
 
-        @param slaveNo : the address of the slave MODBUS device to drive
+        @param subordinateNo : the address of the subordinate MODBUS device to drive
         @param pduAddr : the relative address of the register to set (zero-based)
         @param value : the 16 bit value to set
 
@@ -1508,7 +1508,7 @@ class YSerialPort(YFunction):
         pdu.append(((value) & (0xff)))
 
 
-        reply = self.queryMODBUS(slaveNo, pdu)
+        reply = self.queryMODBUS(subordinateNo, pdu)
         if len(reply) == 0:
             return res
         if reply[0] != pdu[0]:
@@ -1516,12 +1516,12 @@ class YSerialPort(YFunction):
         res = 1
         return res
 
-    def modbusWriteRegisters(self, slaveNo, pduAddr, values):
+    def modbusWriteRegisters(self, subordinateNo, pduAddr, values):
         """
         Sets several contiguous internal registers (or holding registers) on a MODBUS serial device.
         This method uses the MODBUS function code 0x10 (Write Multiple Registers).
 
-        @param slaveNo : the address of the slave MODBUS device to drive
+        @param subordinateNo : the address of the subordinate MODBUS device to drive
         @param pduAddr : the relative address of the first internal register to set (zero-based)
         @param values : the vector of 16 bit values to set
 
@@ -1554,7 +1554,7 @@ class YSerialPort(YFunction):
             regpos = regpos + 1
 
 
-        reply = self.queryMODBUS(slaveNo, pdu)
+        reply = self.queryMODBUS(subordinateNo, pdu)
         if len(reply) == 0:
             return res
         if reply[0] != pdu[0]:
@@ -1563,13 +1563,13 @@ class YSerialPort(YFunction):
         res = res + reply[4]
         return res
 
-    def modbusWriteAndReadRegisters(self, slaveNo, pduWriteAddr, values, pduReadAddr, nReadWords):
+    def modbusWriteAndReadRegisters(self, subordinateNo, pduWriteAddr, values, pduReadAddr, nReadWords):
         """
         Sets several contiguous internal registers (holding registers) on a MODBUS serial device,
         then performs a contiguous read of a set of (possibly different) internal registers.
         This method uses the MODBUS function code 0x17 (Read/Write Multiple Registers).
 
-        @param slaveNo : the address of the slave MODBUS device to drive
+        @param subordinateNo : the address of the subordinate MODBUS device to drive
         @param pduWriteAddr : the relative address of the first internal register to set (zero-based)
         @param values : the vector of 16 bit values to set
         @param pduReadAddr : the relative address of the first internal register to read (zero-based)
@@ -1608,7 +1608,7 @@ class YSerialPort(YFunction):
             regpos = regpos + 1
 
 
-        reply = self.queryMODBUS(slaveNo, pdu)
+        reply = self.queryMODBUS(subordinateNo, pdu)
         if len(reply) == 0:
             return res
         if reply[0] != pdu[0]:


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.